### PR TITLE
Implement syscall handlers (b), increase PC on syscall (c)

### DIFF
--- a/build_test.sh
+++ b/build_test.sh
@@ -5,3 +5,4 @@ cd code/test
 make
 
 ../build.linux/nachos -x halt
+../build.linux/nachos -x test_syscall

--- a/code/test/Makefile
+++ b/code/test/Makefile
@@ -40,11 +40,11 @@
 #
 #    Nachos assumes that the location of the program startup routine (the
 # 	location the kernel jumps to when the program initially starts up)
-#       is at location 0.  This means: start.o must be the first .o passed 
+#       is at location 0.  This means: start.o must be the first .o passed
 # 	to ld, in order for the routine "Start" to be loaded at location 0
 #
 #    When you make the test programs, you will see messages like these:
-#		numsections 3 
+#		numsections 3
 #		Loading 3 sections:
 #		        ".text", filepos 0xd0, mempos 0x0, size 0x440
 #		        ".data", filepos 0x510, mempos 0x440, size 0x0
@@ -112,7 +112,7 @@ ifeq ($(hosttype),unknown)
 PROGRAMS = unknownhost
 else
 # change this if you create a new test program!
-PROGRAMS = add halt shell matmult sort segments
+PROGRAMS = add halt shell matmult sort segments test_syscall
 endif
 
 all: $(PROGRAMS)
@@ -156,6 +156,13 @@ matmult.o: matmult.c
 matmult: matmult.o start.o
 	$(LD) $(LDFLAGS) start.o matmult.o -o matmult.coff
 	$(COFF2NOFF) matmult.coff matmult
+
+test_syscall.o: test_syscall.c
+	$(CC) $(CFLAGS) -c test_syscall.c
+test_syscall: test_syscall.o start.o
+	$(LD) $(LDFLAGS) start.o test_syscall.o -o test_syscall.coff
+	$(COFF2NOFF) test_syscall.coff test_syscall
+
 
 clean:
 	$(RM) -f *.o *.ii

--- a/code/test/start.S
+++ b/code/test/start.S
@@ -1,4 +1,4 @@
-/* Start.s 
+/* Start.s
  *	Assembly language assist for user programs running on top of Nachos.
  *
  *	Since we don't want to pull in the entire C library, we define
@@ -9,12 +9,12 @@
 #define IN_ASM
 #include "syscall.h"
 
-        .text   
+        .text
         .align  2
 
 /* -------------------------------------------------------------
  * __start
- *	Initialize running a C program, by calling "main". 
+ *	Initialize running a C program, by calling "main".
  *
  * 	NOTE: This has to be first, so that it gets loaded at location 0.
  *	The Nachos kernel always starts a program by jumping to location 0.
@@ -25,7 +25,7 @@
 	.ent	__start
 __start:
 	jal	main
-	move	$4,$0		
+	move	$4,$0
 	jal	Exit	 /* if we return from main, exit(0) */
 	.end __start
 
@@ -34,7 +34,7 @@ __start:
  *	Assembly language assist to make system calls to the Nachos kernel.
  *	There is one stub per system call, that places the code for the
  *	system call into register r2, and leaves the arguments to the
- *	system call alone (in other words, arg1 is in r4, arg2 is 
+ *	system call alone (in other words, arg1 is in r4, arg2 is
  *	in r5, arg3 is in r6, arg4 is in r7)
  *
  * 	The return value is in r2. This follows the standard C calling
@@ -177,11 +177,10 @@ ThreadJoin:
 	syscall
 	j 	$31
 	.end ThreadJoin
-	
+
 /* dummy function to keep gcc happy */
         .globl  __main
         .ent    __main
 __main:
         j       $31
         .end    __main
-

--- a/code/test/test_syscall.c
+++ b/code/test/test_syscall.c
@@ -1,0 +1,12 @@
+/* test_syscall.c
+ *	Simple program to test whether the systemcall interface works.
+ */
+
+#include "syscall.h"
+
+int main() {
+    int result = Add(1, 2);
+    /* Don't need to Halt() anymore because the PC will increase automatically
+     */
+    result = Add(2, 3);
+}


### PR DESCRIPTION
Add `handle_not_implemented_SC()` to handle all syscalls
that have not yet been implemented. That method will write debug
log and increase the program counter.

Now user test programs don't need to call Halt() at the end
of the program.